### PR TITLE
Significantly accelerate (de)allocation by swapping the naive log2() with CLZ intrinsics

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,18 @@ If not specified, the macro expands as follows:
   For example, for GCC, Clang, and ARM Compiler, it expands into `__builtin_expect((x), 1)`.
 - For other (unknown) compilers it expands into the original expression with no modifications: `(x)`.
 
+#### O1HEAP_CLZ(x)
+
+The count leading zeros (CLZ) function is used for fast binary logarithm computation (which has to be done
+multiple times per allocation, so its performance is critical).
+Most of the modern processors implement dedicated hardware support for fast CLZ computation,
+which is available via compiler intrinsics.
+
+If not overridden by the user, for some compilers `O1HEAP_CLZ(x)` will expand to the appropriate intrinsic
+(e.g., `__builtin_clzl(x)` for GCC/Clang).
+For other compilers it will default to a slow software implementation,
+which is likely to significantly degrade the performance of the library.
+
 ## Development
 
 ### Dependencies
@@ -256,6 +268,13 @@ An exception applies for the case of false-positive (invalid) warnings -- those 
 - *[Russian]* [Динамическая память в системах жёсткого реального времени](https://habr.com/ru/post/486650/) -- issues with dynamic memory allocation in modern embedded RTOS and related popular misconceptions.
 
 ## Changelog
+
+### v2.1
+
+- Significantly accelerate (de-)allocation by replacing the naïve log2 implementation with fast CLZ intrinsics;
+  see `O1HEAP_CLZ(x)`.
+- Do not require char to be 8-bit wide: replace `uint8_t` with `uint_fast8_t`.
+  This is to enhance compatibility with odd embedded platforms where `CHAR_BIT!=8` (e.g., ADSP TS-201, TMS320C2804).
 
 ### v2.0
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ due to the fact that a memory allocator has to rely on inherently unsafe operati
 The codebase is extremely compact (<500 LoC) and is therefore trivial to validate.
 
 The allocator is designed to be portable across all conventional architectures, from 8-bit to 64-bit systems.
-Multi-threaded environments are supported with the help of external synchronization hooks provided by the application.
 
 ## Design
 

--- a/tests/.idea/dictionaries/pavel.xml
+++ b/tests/.idea/dictionaries/pavel.xml
@@ -1,9 +1,11 @@
 <component name="ProjectDictionaryState">
   <dictionary name="pavel">
     <words>
+      <w>adsp</w>
       <w>deallocation</w>
       <w>herter</w>
       <w>kirienko</w>
+      <w>naïve</w>
       <w>noninfringement</w>
       <w>nosonar</w>
       <w>ogasawara</w>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -78,14 +78,16 @@ function(gen_test name files compile_definitions compile_features compile_flags 
     add_test("run_${name}" "${name}" --rng-seed time)
 endfunction()
 
-function(gen_test_matrix name files compile_definitions)
-    gen_test("${name}_c99_x64" "${files}" "${compile_definitions}" c_std_99 "-m64" "-m64")
-    gen_test("${name}_c99_x32" "${files}" "${compile_definitions}" c_std_99 "-m32" "-m32")
-    gen_test("${name}_c11_x64" "${files}" "${compile_definitions}" c_std_11 "-m64" "-m64")
-    gen_test("${name}_c11_x32" "${files}" "${compile_definitions}" c_std_11 "-m32" "-m32")
+function(gen_test_matrix name files defs)
+    gen_test("${name}_c99_x64"      "${files}" "${defs}"                            c_std_99 "-m64" "-m64")
+    gen_test("${name}_c99_x32"      "${files}" "${defs}"                            c_std_99 "-m32" "-m32")
+    gen_test("${name}_c11_x64"      "${files}" "${defs}"                            c_std_11 "-m64" "-m64")
+    gen_test("${name}_c11_x32"      "${files}" "${defs}"                            c_std_11 "-m32" "-m32")
+    gen_test("${name}_c11_x64_ni"   "${files}" "${defs};O1HEAP_USE_INTRINSICS=0"    c_std_11 "-m64" "-m64")
+    gen_test("${name}_c11_x32_ni"   "${files}" "${defs};O1HEAP_USE_INTRINSICS=0"    c_std_11 "-m32" "-m32")
     # Coverage is only available for GCC builds.
     if ((CMAKE_CXX_COMPILER_ID STREQUAL "GNU") AND (CMAKE_BUILD_TYPE STREQUAL "Debug"))
-        gen_test("${name}_cov" "${files}" "${compile_definitions}" c_std_11 "-g -O0 --coverage" "--coverage")
+        gen_test("${name}_cov" "${files}" "${defs}" c_std_11 "-g -O0 --coverage" "--coverage")
     endif ()
 endfunction()
 

--- a/tests/internal.hpp
+++ b/tests/internal.hpp
@@ -34,10 +34,10 @@
 namespace internal
 {
 extern "C" {
-auto isPowerOf2(const std::size_t x) -> bool;
 auto log2Floor(const std::size_t x) -> std::uint8_t;
 auto log2Ceil(const std::size_t x) -> std::uint8_t;
 auto pow2(const std::uint8_t power) -> std::size_t;
+auto roundUpToPowerOf2(const std::size_t x) -> std::size_t;
 }
 
 struct Fragment;

--- a/tests/test_private.cpp
+++ b/tests/test_private.cpp
@@ -16,26 +16,11 @@
 
 #include "internal.hpp"
 
-TEST_CASE("Private: isPowerOf2")
-{
-    using internal::isPowerOf2;
-    REQUIRE(isPowerOf2(0));  // Special case.
-    REQUIRE(isPowerOf2(1));  // 2**0
-    REQUIRE(isPowerOf2(2));  // 2**1
-    REQUIRE(!isPowerOf2(3));
-    REQUIRE(isPowerOf2(4));
-    REQUIRE(!isPowerOf2(5));
-    REQUIRE(!isPowerOf2(6));
-    REQUIRE(!isPowerOf2(7));
-    REQUIRE(isPowerOf2(8));
-    REQUIRE(!isPowerOf2(9));
-}
-
 TEST_CASE("Private: log2")
 {
     using internal::log2Floor;
     using internal::log2Ceil;
-    REQUIRE(log2Floor(0) == 0);
+    // The function is only defined for x>=1.
     REQUIRE(log2Floor(1) == 0);
     REQUIRE(log2Floor(2) == 1);
     REQUIRE(log2Floor(3) == 1);
@@ -44,7 +29,7 @@ TEST_CASE("Private: log2")
     REQUIRE(log2Floor(60) == 5);
     REQUIRE(log2Floor(64) == 6);
 
-    REQUIRE(log2Ceil(0) == 0);
+    REQUIRE(log2Ceil(0) == 0);  // Special case.
     REQUIRE(log2Ceil(1) == 0);
     REQUIRE(log2Ceil(2) == 1);
     REQUIRE(log2Ceil(3) == 2);
@@ -67,4 +52,35 @@ TEST_CASE("Private: pow2")
     REQUIRE(pow2(7) == 128);
     REQUIRE(pow2(8) == 256);
     REQUIRE(pow2(9) == 512);
+}
+
+TEST_CASE("Private: roundUpToPowerOf2")
+{
+    using internal::log2Ceil;
+    using internal::pow2;
+    using internal::roundUpToPowerOf2;
+    // The function is only defined for x>=2.
+    REQUIRE(roundUpToPowerOf2(2) == 2);
+    REQUIRE(roundUpToPowerOf2(3) == 4);
+    REQUIRE(roundUpToPowerOf2(4) == 4);
+    REQUIRE(roundUpToPowerOf2(5) == 8);
+    REQUIRE(roundUpToPowerOf2(6) == 8);
+    REQUIRE(roundUpToPowerOf2(7) == 8);
+    REQUIRE(roundUpToPowerOf2(8) == 8);
+    REQUIRE(roundUpToPowerOf2(9) == 16);
+    REQUIRE(roundUpToPowerOf2(10) == 16);
+    REQUIRE(roundUpToPowerOf2(11) == 16);
+    REQUIRE(roundUpToPowerOf2(12) == 16);
+    REQUIRE(roundUpToPowerOf2(13) == 16);
+    REQUIRE(roundUpToPowerOf2(14) == 16);
+    REQUIRE(roundUpToPowerOf2(15) == 16);
+    REQUIRE(roundUpToPowerOf2(16) == 16);
+    REQUIRE(roundUpToPowerOf2(17) == 32);
+    REQUIRE(roundUpToPowerOf2(32) == 32);
+    REQUIRE(roundUpToPowerOf2(2147483647U) == 2147483648U);
+    REQUIRE(roundUpToPowerOf2(2147483648U) == 2147483648U);
+    for (auto i = 2U; i < 1'000'000; i++)
+    {
+        REQUIRE(pow2(log2Ceil(i)) == roundUpToPowerOf2(i));
+    }
 }


### PR DESCRIPTION
In the following diagrams, the middle signal is at the high level while allocation is in progress. The profiling was done on ARM Cortex-M4. The other signals are irrelevant.

Before:

<img width="684" alt="alloc-without-clz" src="https://user-images.githubusercontent.com/3298404/143722496-446eb5cb-25b1-4a33-b068-4d260479b5fd.png">

After:

<img width="414" alt="alloc-with-clz-b" src="https://user-images.githubusercontent.com/3298404/143722501-6456cb6f-88e5-4bc3-989d-b2ce748b0300.png">

~2.5x performance improvement.